### PR TITLE
Fix NoSuchMethodError: LivingDamageEvent.Post.getNewDamage on NeoForge 26.1

### DIFF
--- a/src/main/java/tallestegg/guardvillagers/HandlerEvents.java
+++ b/src/main/java/tallestegg/guardvillagers/HandlerEvents.java
@@ -351,7 +351,7 @@ public class HandlerEvents {
 
         if (!(arrow.getOwner() instanceof Guard)) return;
 
-        if (event.getNewDamage() <= 0.0F) return;
+        if (event.getHealthDamage() <= 0.0F) return;
 
         arrow.discard();
     }


### PR DESCRIPTION
## Summary

- Fixes a server crash (`NoSuchMethodError`) when any living entity takes damage while Guard Villagers is loaded on NeoForge 26.1.2+.
- Replaces the removed `LivingDamageEvent.Post#getNewDamage()` call with `getHealthDamage()`, which is the correct accessor for final health loss in the reworked damage pipeline.

## Problem

NeoForge reworked the living damage events. `LivingDamageEvent.Post` is now an immutable snapshot and no longer exposes `getNewDamage()`. The handler `onEntityDamaged` still calls that method, which causes:

```
java.lang.NoSuchMethodError: 'float net.neoforged.neoforge.event.entity.living.LivingDamageEvent$Post.getNewDamage()'
    at tallestegg.guardvillagers.HandlerEvents.onEntityDamaged(HandlerEvents.java:354)
```

This triggers whenever `LivingDamageEvent.Post` is fired (for example when a projectile damages a mob), not only for guard-specific interactions.

## Solution

In `HandlerEvents.onEntityDamaged`, use `event.getHealthDamage()` instead of `event.getNewDamage()`. According to NeoForge’s `LivingDamageEvent.Post` Javadoc, `getHealthDamage()` returns the amount of health the entity lost after the full damage sequence — which matches the intent of the existing early-return check before discarding guard-owned arrows.

Reference (NeoForge 26.1.x): https://github.com/neoforged/NeoForge/blob/26.1.x/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java

## Test plan

- [ ] Build the mod against NeoForge 26.1.2.x
- [ ] Load a world with Guard Villagers enabled
- [ ] Damage hostile mobs with guard-owned arrows and other damage sources
- [ ] Confirm the server no longer crashes with `NoSuchMethodError` on `getNewDamage()`
- [ ] Confirm guard arrows are still discarded when damage is applied as expected

--- 

Made with Cursor